### PR TITLE
Fix marking current level in `offcanvas-navigation`

### DIFF
--- a/src/components/offcanvas-navigation/offcanvas-navigation.ts
+++ b/src/components/offcanvas-navigation/offcanvas-navigation.ts
@@ -268,6 +268,16 @@ export default class OffcanvasNavigation {
     }
 
     /**
+     * Shows root list.
+     */
+    protected _showRootLevel(): void {
+        this._$element
+            .find(`.${this._options.className}__list`)
+            .eq(0)
+            .addClass(`${this._options.className}__list--current`);
+    }
+
+    /**
      * Shows navigation level list.
      * @param {jQuery} $levelToShow ${this._options.className}__list element which should be shown.
      */
@@ -334,6 +344,7 @@ export default class OffcanvasNavigation {
             .closest(`.${this._options.className}__list`)
             .addClass(`${this._options.className}__list--current`);
     }
+
     /**
      * Resets levels to root.
      */
@@ -349,12 +360,10 @@ export default class OffcanvasNavigation {
         if (this._options.showActiveCategoryLevel) {
             this._showActiveCategoryLevel();
         } else {
-            // Set root level to current.
-            $levelsToHide
-                .eq(0)
-                .addClass(`${this._options.className}__list--current`);
+            this._showRootLevel();
         }
     }
+
     /**
      * Sets up event listeners for a component.
      */
@@ -382,6 +391,7 @@ export default class OffcanvasNavigation {
             this._eventListeners.returnLinkClick
         );
     }
+
     /**
      * Removes event listeners for a component.
      */
@@ -391,11 +401,13 @@ export default class OffcanvasNavigation {
         this._$drawer.off('click', this._eventListeners.parentLinkClick);
         this._$drawer.off('click', this._eventListeners.returnLinkClick);
     }
+
     /**
      * Shows current category level in navigation (or parent category level if there is no nested category).
      */
     protected _showActiveCategoryLevel(): void {
         if (this._activeCategoryPath.length <= 1) {
+            this._showRootLevel();
             return;
         }
 
@@ -419,6 +431,7 @@ export default class OffcanvasNavigation {
             this._showCategoryLevel(parentCategoryId);
         }
     }
+
     /**
      * Adds highlight classname to active category list item
      */

--- a/src/components/offcanvas-navigation/offcanvas-navigation.ts
+++ b/src/components/offcanvas-navigation/offcanvas-navigation.ts
@@ -349,6 +349,10 @@ export default class OffcanvasNavigation {
      * Resets levels to root.
      */
     protected _resetLevels(): void {
+        if (!this._$element) {
+            return;
+        }
+
         const $levelsToHide = this._$element.find(
             `.${this._options.className}__list`
         );


### PR DESCRIPTION
This fixes two bugs:

1. https://github.com/magesuite/theme-creativeshop/commit/924575e5fcb8d4f813401046e3364f22b5cc36c7 :
    - now: go on a homepage (where there is no active category). open offcanvas. (it'll be ok now) close it. open again. result: the root level is not set as current (and thus, scrolling in the offcanvas is impossible, which causes trouble especially on smaller mobile devices)
    - after: everything's ok

2. https://github.com/magesuite/theme-creativeshop/commit/840416db5a06f78dcc92c19a692715fd9064344b
    - now: if you very quickly open and close offcanvas, (while it is still loading), it will trigger a JS error upon closing
    - after: everything's ok.

Tested on our shop, should be good.