### PR TITLE
fix(toolbar): Use `cursor: pointer` on pagination buttons

### DIFF
--- a/src/components/toolbar/mixins.scss
+++ b/src/components/toolbar/mixins.scss
@@ -87,6 +87,7 @@ $pagination-number--hover_text-decoration: inherit !default;
     margin: 0;
     padding: $pagination-number_padding;
     background: $pagination-number_background;
+    cursor: pointer;
     line-height: 1;
     font-size: $pagination-number_font-size;
     font-weight: $pagination-number_font-weight;


### PR DESCRIPTION
**Before the change:**

Pagination buttons (the ones from the screen below , visible e.g. at https://demo.magesuite.io/men.html ) do not have pointer cursor, in contrary to all the other buttons in the toolbar.

![image](https://user-images.githubusercontent.com/1862580/79070218-9b61a480-7cd4-11ea-8889-cc4c579b378c.png)

**After the change:**

They do.