### PR TITLE
fix(minicart/content.html): Show empty cart message

### DIFF
--- a/src/Magento_Checkout/web/template/minicart/content.html
+++ b/src/Magento_Checkout/web/template/minicart/content.html
@@ -100,30 +100,12 @@
             <!-- ko ifnot: getCartParam('summary_count') -->
             <strong
                 class="subtitle empty cs-minicart__empty"
-                data-bind="visible: closeSidebar(), i18n: 'You have no items in your shopping cart.'"
+                data-bind="i18n: 'You have no items in your shopping cart.'"
             ></strong>
-            <!-- ko if: getCartParam('cart_empty_message') -->
             <p
                 class="minicart empty text cs-minicart__empty"
                 data-bind="text: getCartParam('cart_empty_message')"
             ></p>
-            <div class="cs-minicart__actions">
-                <a
-                    class="action viewcart cs-minicart__button-viewcart"
-                    data-bind="attr: {href: shoppingCartUrl}"
-                >
-                    <span
-                        class="cs-minicart__button-viewcart-span"
-                        data-bind="i18n: 'View and Edit Cart'"
-                    ></span>
-                    <img
-                        class="inline-svg cs-minicart__button-viewcart-icon"
-                        data-bind="attr: { src: require.toUrl('images/icons/minicart/icon-edit-cart.svg') }"
-                        alt=""
-                    />
-                </a>
-            </div>
-            <!-- /ko -->
             <!-- /ko -->
             <!-- ko if: getCartParam('summary_count') -->
             <div class="actions cs-minicart__actions">


### PR DESCRIPTION
Template is currently weird. Why is it doing `visible: closeSidebar()` ? Why is it trying to show "Edit cart" buttons if empty cart message is present? 

Maybe because of some merge conflicts the template got broken. This commit fixes it.