### PR TITLE
[FIX] Build theme on linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dependencies": {
         "@creativestyle/magesuite-frontend-builder": "^2.4.2",
         "@types/requirejs": "^2.1.31",
+        "gifsicle": "^4.0",
         "include-media": "^1.4.9"
     }
 }


### PR DESCRIPTION
New versions of linux have no gifsicle@5.1.0 and theme cannot be generated.