### PR TITLE
fix(addtocart): Fix `Cannot read property 'length' of null` error

### DIFF
--- a/src/components/addtocart/addtocart.ts
+++ b/src/components/addtocart/addtocart.ts
@@ -134,7 +134,7 @@ interface IOffcanvasMinicartXmlSettings {
  */
 export default class AddToCart {
     private _$source: JQuery<HTMLElement>;
-    private _$component: JQuery<HTMLElement>;
+    private _$component?: JQuery<HTMLElement>;
     private _$button: JQuery<HTMLElement>;
     private _animationTimeout: ReturnType<typeof setTimeout>;
     private _visibilityTimeout: ReturnType<typeof setTimeout>;
@@ -242,7 +242,7 @@ export default class AddToCart {
         const actionFailed: boolean =
             ajaxRes.response.backUrl || ajaxRes.response.messages;
 
-        if (this._$component.length && actionFailed) {
+        if (this._$component && this._$component.length && actionFailed) {
             this._$component.addClass(
                 `${this._options.componentClass}--no-transitions`
             );
@@ -260,7 +260,8 @@ export default class AddToCart {
             if (
                 !actionFailed &&
                 this._options.animateMinicart &&
-                this._options.animateMinicartWithCustomDoneHandler
+                this._options.animateMinicartWithCustomDoneHandler &&
+                this._$component
             ) {
                 this._startQtyUpdate(this._$component);
             }

--- a/src/components/addtocart/addtocart.ts
+++ b/src/components/addtocart/addtocart.ts
@@ -135,7 +135,7 @@ interface IOffcanvasMinicartXmlSettings {
 export default class AddToCart {
     private _$source: JQuery<HTMLElement>;
     private _$component?: JQuery<HTMLElement>;
-    private _$button: JQuery<HTMLElement>;
+    private _$button?: JQuery<HTMLElement>;
     private _animationTimeout: ReturnType<typeof setTimeout>;
     private _visibilityTimeout: ReturnType<typeof setTimeout>;
     private _allDoneTimeout: ReturnType<typeof setTimeout>;
@@ -178,8 +178,6 @@ export default class AddToCart {
             'vars.Magento_Checkout.minicart_offcanvas'
         );
 
-        this._$component = null;
-        this._$button = null;
         this._animationTimeout = null;
         this._visibilityTimeout = null;
         this._allDoneTimeout = null;
@@ -242,13 +240,21 @@ export default class AddToCart {
         const actionFailed: boolean =
             ajaxRes.response.backUrl || ajaxRes.response.messages;
 
+        if (!this._$component || !this._$component.length) {
+            console.warn(
+                `AddToCart._onDone has been called while this._$component is empty.
+Weird. Might be the cause why minicart isn't updated correctly.
+See https://github.com/magesuite/theme-creativeshop/pull/48 for more info.`
+            );
+        }
+
         if (this._$component && this._$component.length && actionFailed) {
             this._$component.addClass(
                 `${this._options.componentClass}--no-transitions`
             );
         }
 
-        if (this._$button.length) {
+        if (this._$button && this._$button.length) {
             this._$button.prop('disabled', false);
         }
 


### PR DESCRIPTION
We have quite a bit of errors on Sentry that look like this:

```
TypeError: Cannot read property 'length' of null
  at t._onDone(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/js/category.js:1:48422)
  at HTMLDocument.<anonymous>(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/js/category.js:1:52633)
  at HTMLDocument.dispatch(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery.js:5232:27)
  at HTMLDocument.elemData.handle(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery.js:4884:29)
  at Object.trigger(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery.js:5136:13)
  at Object.jQuery.event.trigger(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery/jquery-migrate.js:633:22)
  at HTMLDocument.<anonymous>(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery.js:5866:18)
  at Function.each(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery.js:376:20)
  at jQuery.fn.init.each(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery.js:142:18)
  at jQuery.fn.init.trigger(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery.js:5865:16)
  at Object.success(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/Magento_Catalog/js/catalog-add-to-cart.js:122:33)
  at fire(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery.js:3238:32)
  at Object.fireWith [as resolveWith](/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery.js:3368:8)
  at done(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery.js:9846:15)
  at XMLHttpRequest.callback(/static/version1607965126/frontend/Creativestyle/theme-groomershop/pl_PL/jquery.js:10317:9)
```
  
Not sure yet how exactly it can be reproduced. But this should fix it. You already have such a check at https://github.com/magesuite/theme-creativeshop/blob/next/src/components/addtocart/addtocart.ts#L268 , so seems like it's just missing at the other places.  