### PR TITLE
fix(swatch-renderer-ext): Only display/hide price tooltips of the clicked product tile cell, not of all cells

### DIFF
--- a/src/Magento_Swatches/web/js/swatch-renderer-ext.js
+++ b/src/Magento_Swatches/web/js/swatch-renderer-ext.js
@@ -249,15 +249,18 @@ define(['jquery', 'underscore', 'mage/translate'], function($, _, $t) {
                 );
             },
             _UpdatePrice: function() {
-                this._super();
-                var $widget = this;
-                var options = _.object(_.keys(this.optionsMap), {});
-                var element = this.element;
-
-                var isPdp = this.options.isPdp;
-                var currentTileSwatchesClass = element.attr('class');
-
-                this.options.classes.attributeOptionsWrapper = isPdp
+                var currentTileSwatchesClass = this.element.attr('class');
+                this.options.normalPriceLabelSelector = this.options.isPdp
+                    ? $(
+                          this.options.selectorPdp +
+                              ' ' +
+                              this.options.normalPriceLabel
+                      )
+                    : $(this.element)
+                          .closest(this.options.selectorProductTile)
+                          .find(this.options.normalPriceLabel);
+                this.options.classes.attributeOptionsWrapper = this.options
+                    .isPdp
                     ? this.options.classes.pdpClass +
                       ' ' +
                       this.options.swatchesWrapper
@@ -266,19 +269,12 @@ define(['jquery', 'underscore', 'mage/translate'], function($, _, $t) {
                       '.' +
                       currentTileSwatchesClass +
                       ' ';
-                this.options.swatchesWrapper;
 
-                this.options.normalPriceLabelSelector = isPdp
-                    ? $(
-                          this.options.selectorPdp +
-                              ' ' +
-                              this.options.normalPriceLabel
-                      )
-                    : $(element)
-                          .closest(this.options.selectorProductTile)
-                          .find(this.options.normalPriceLabel);
+                this._super();
 
-                element
+                var options = _.object(_.keys(this.optionsMap), {});
+
+                this.element
                     .find(
                         '.' +
                             this.options.classes.attributeClass +
@@ -286,7 +282,6 @@ define(['jquery', 'underscore', 'mage/translate'], function($, _, $t) {
                     )
                     .each(function() {
                         var attributeId = $(this).attr('attribute-id');
-
                         options[attributeId] = $(this).attr('option-selected');
                     });
 
@@ -301,26 +296,8 @@ define(['jquery', 'underscore', 'mage/translate'], function($, _, $t) {
                 $(
                     '.normal-price .price-final_price .price-wrapper .price'
                 ).toggleClass('discounted-price', $discounted);
-
-                $widget._UpdateTilePriceLabel();
             },
 
-            // Show 'From' price label on exact tile instead of all of tiles.
-            _UpdateTilePriceLabel: function() {
-                var $tileNormalPriceLabelSelector = $(
-                    this.options.selectorProductTile +
-                        ' ' +
-                        this.options.normalPriceLabel
-                );
-
-                var $tilePriceLabel = $(
-                    $(this.element)
-                        .closest($(this.options.selectorProductTile))
-                        .find($tileNormalPriceLabelSelector)
-                );
-
-                $tileNormalPriceLabelSelector.not($tilePriceLabel).hide();
-            },
             /**
              * For now swatches on tiles in Magesuite are not clickable.
              * Swatches area on tiles works as a link to PDP.


### PR DESCRIPTION
When user is on a product listing page (e.g. category), and there are products with swatches, then the product has "From xxx" price. If user selects swatch, the price should change to "xxx" (the "From" word should disappear), but only for that one product.

However currently that "From" is hidden on all product tiles.

This commit fixes it.

For more info, see videos:

Before the change:

https://user-images.githubusercontent.com/1862580/103486100-86e1b100-4dfb-11eb-8016-9e76e499cdc8.mov



After the change:


https://user-images.githubusercontent.com/1862580/103486109-8ea15580-4dfb-11eb-88d1-5a4e11acc64a.mov

