### PR TITLE
fix(swatch-renderer-ext): Make prices be updated also in list mode view

### DIFF
--- a/src/Magento_Swatches/web/js/swatch-renderer-ext.js
+++ b/src/Magento_Swatches/web/js/swatch-renderer-ext.js
@@ -32,6 +32,9 @@ define(['jquery', 'underscore', 'mage/translate'], function($, _, $t) {
                     return;
                 }
 
+                this.options.selectorProduct =
+                    '.product-info-main, .cs-product-tile';
+
                 this._super();
 
                 var isPdp = this.element.parents(this.options.selectorPdp)


### PR DESCRIPTION
Currently there are two `.price-box` divs per each `.cs-product-tile` (1 for grid view, 1 for list view), and only one of them (the grid view one) is contained in the default `this.options.selectorProduct` which is `.product-info-main`.

Because of that, currently if user selects a swatch in the product listing in list view mode, the price is not updated. (It is updated only in grid view mode).

This PR fixes it.