### PR TITLE
Remove German HTML comment from default root template

### DIFF
--- a/src/Magento_Theme/templates/root.phtml
+++ b/src/Magento_Theme/templates/root.phtml
@@ -10,13 +10,6 @@
 <!doctype html>
 <html <?php /* @escapeNotVerified */ echo $htmlAttributes ?>>
     <head <?php /* @escapeNotVerified */ echo $headAttributes ?>>
-        <!-- 
-        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
-        #
-        #        Dieser Onlineshop wurde von der Agentur www.creativestyle.de umgesetzt         #
-        #
-        # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # 
-        -->
         <?php /* @escapeNotVerified */ echo $requireJs ?>
         <?php /* @escapeNotVerified */ echo $headContent ?>
         <?php /* @escapeNotVerified */ echo $headAdditional ?>


### PR DESCRIPTION
Not sure if this is an oversight, but it seems a bit odd to me that there is a HTML comment in the root template, saying that "this webshop was created by the www.creativestyle.de agency" whereas in reality the respective webshop was implemented by whoever is using the Creativeshop Theme as a base 🙂. Also the comment is in German rather than international English.