### PR TITLE
Remove superfluous quotes

### DIFF
--- a/src/Magento_Checkout/templates/cart/minicart.phtml
+++ b/src/Magento_Checkout/templates/cart/minicart.phtml
@@ -19,7 +19,7 @@ $actionClasses = $isOffcanvas ? $block->getOffcanvasTriggerClass() : 'showcart';
             <?php endif; ?> 
             data-bind="scope: 'minicart_content'"
         >
-            <div class="cs-header-user-nav__icon-wrapper"" data-bind="css: { 'cs-header-user-nav__icon-wrapper--with-items': getCartParam('summary_count') > 0 }">
+            <div class="cs-header-user-nav__icon-wrapper" data-bind="css: { 'cs-header-user-nav__icon-wrapper--with-items': getCartParam('summary_count') > 0 }">
                 <?= $block->getChildHtml('minicart.icon'); ?>
                 <span class="counter qty empty cs-header-user-nav__qty-counter <?= $block->getBadgeAdditionalCssClasses() ?>" data-bind="css: { 'cs-header-user-nav__qty-counter--have-items': getCartParam('summary_count') > 0, 'cs-header-user-nav__qty-counter--empty': !getCartParam('summary_count') }">
                     <span class="cs-header-user-nav__qty-counter-span cs-addtocart__minicart-qty-text">


### PR DESCRIPTION
The current `Magento_Checkout/templates/cart/minicart.phtml` template contains a superfluous double-quote resulting in invalid HTML output.