### PR TITLE
Remove disallowed display attribute

### DIFF
--- a/src/Magento_Catalog/layout/catalog_category_view.xml
+++ b/src/Magento_Catalog/layout/catalog_category_view.xml
@@ -90,7 +90,7 @@
 
         <!-- Page scroll -->
         <referenceContainer name="footer-container">
-            <block name="page.scroll" template="MageSuite_ThemeHelpers::page-scroll.phtml" after="-" display="false">
+            <block name="page.scroll" template="MageSuite_ThemeHelpers::page-scroll.phtml" after="-">
                 <arguments> 
                     <argument name="additional_css_classes" xsi:type="string"></argument>
                     <argument name="show_label" xsi:type="boolean">false</argument>


### PR DESCRIPTION
Currently the following error occurs (in `developer` mode) in Magento `2.4.3`:

```
1 exception(s):
Exception #0 (Magento\Framework\Config\Dom\ValidationException): Element 'block', attribute 'display': The attribute 'display' is not allowed.
Line: 2804


Exception #0 (Magento\Framework\Config\Dom\ValidationException): Element 'block', attribute 'display': The attribute 'display' is not allowed.
Line: 2804

<pre>#1 Magento\Framework\Config\Dom->__construct() called at [vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php:121]
#2 Magento\Framework\ObjectManager\Factory\AbstractFactory->createObject() called at [vendor/magento/framework/ObjectManager/Factory/Dynamic/Developer.php:66]
#3 Magento\Framework\ObjectManager\Factory\Dynamic\Developer->create() called at [vendor/magento/framework/ObjectManager/ObjectManager.php:56]
#4 Magento\Framework\ObjectManager\ObjectManager->create() called at [vendor/magento/framework/Config/DomFactory.php:43]
#5 Magento\Framework\Config\DomFactory->createDom() called at [vendor/magento/framework/View/Model/Layout/Update/Validator.php:141]
#6 Magento\Framework\View\Model\Layout\Update\Validator->isValid() called at [vendor/magento/framework/View/Model/Layout/Merge.php:524]
#7 Magento\Framework\View\Model\Layout\Merge->_validateMergedLayout() called at [vendor/magento/framework/View/Model/Layout/Merge.php:500]
#8 Magento\Framework\View\Model\Layout\Merge->load() called at [generated/code/Magento/Framework/View/Model/Layout/Merge/Interceptor.php:149]
#9 Magento\Framework\View\Model\Layout\Merge\Interceptor->load() called at [vendor/magento/framework/View/Layout/Builder.php:86]
#10 Magento\Framework\View\Layout\Builder->loadLayoutUpdates() called at [vendor/magento/framework/View/Layout/Builder.php:63]
#11 Magento\Framework\View\Layout\Builder->build() called at [vendor/magento/framework/View/Page/Config.php:224]
#12 Magento\Framework\View\Page\Config->build() called at [vendor/magento/framework/View/Page/Config.php:587]
#13 Magento\Framework\View\Page\Config->getElementAttribute() called at [generated/code/Magento/Framework/View/Page/Config/Interceptor.php:248]
#14 Magento\Framework\View\Page\Config\Interceptor->getElementAttribute() called at [vendor/magento/framework/View/Page/Config.php:545]
#15 Magento\Framework\View\Page\Config->addBodyClass() called at [generated/code/Magento/Framework/View/Page/Config/Interceptor.php:230]
#16 Magento\Framework\View\Page\Config\Interceptor->addBodyClass() called at [vendor/magento/module-catalog/Controller/Category/View.php:249]
#17 Magento\Catalog\Controller\Category\View->execute() called at [vendor/magento/framework/Interception/Interceptor.php:58]
…
```

The `display` attribute is not allowed on the `<block>` element in layout files. It is only allowed for `<referenceContainer>` or `<referenceBlock>`.

I am not sure what the original purpose of `display="false"` for this particular block was though.