### PR TITLE
Remove non-existing variables

### DIFF
--- a/src/Magento_Ui/web/templates/form/element/input.html
+++ b/src/Magento_Ui/web/templates/form/element/input.html
@@ -16,8 +16,5 @@
         'aria-invalid': error() ? true : 'false',
         id: uid,
         disabled: disabled,
-        type: type,
-        autocomplete: autocomplete,
-        pattern: pattern,
         maxlength: maxlength
     }" />


### PR DESCRIPTION
See https://github.com/magesuite/theme-creativeshop/issues/95

The changes in https://github.com/magesuite/theme-creativeshop/compare/v15.1.6...v15.1.7 break the checkout, because the variables type, pattern and autocomplete will not actually be defined.
